### PR TITLE
Update WalkToActionHandler.java

### DIFF
--- a/vscape Server/src/com/rs2/model/players/WalkToActionHandler.java
+++ b/vscape Server/src/com/rs2/model/players/WalkToActionHandler.java
@@ -2613,6 +2613,7 @@ public class WalkToActionHandler {
 						{
 							player.getActionSender().sendMessage("You dip your amulet into the fountain...");
 							player.getUpdateFlags().sendAnimation(827, 0);
+							player.getInventory().removeItem(new Item(item)); //fixed "full inventory" error when you have 28 glories
 							player.getInventory().addItemToSlot(new Item(1712, 1), player.getSlot());
 						}
 					}


### PR DESCRIPTION
Fixes the "you don't have enough space" error when you have 28 glories and you're trying to recharge them.
