### PR TITLE
more drop stuff

### DIFF
--- a/vscape Server/datajson/npcs/npcDrops.json
+++ b/vscape Server/datajson/npcs/npcDrops.json
@@ -11766,9 +11766,9 @@
       {
         "id": 563,
         "count": [
-          45
+          3
         ],
-        "chance": 2
+        "chance": 6
       },
       {
         "id": 995,
@@ -84133,6 +84133,189 @@
     ]
   },
   {
+  "npcId": 1317,
+    "rareTableAccess": false,
+    "drops": [
+      {
+        "id": 526,
+        "count": [
+          1
+        ],
+        "chance": 1
+      },
+      {
+	   "id": 199,
+        "count": [
+          1
+        ],
+        "chance": 3
+      },
+      {
+	   "id": 201,
+        "count": [
+          1
+        ],
+        "chance": 3
+      },
+      {
+	   "id": 203,
+        "count": [
+          1
+        ],
+        "chance": 3
+      },
+      {
+	   "id": 205,
+        "count": [
+          1
+        ],
+        "chance": 3
+      },
+      {
+	   "id": 217,
+        "count": [
+          1
+        ],
+        "chance": 5
+      },
+      {
+	    "id": 995,
+        "count": [
+          3,
+		  20,
+		  27
+        ],
+        "chance": 2
+      },
+      {
+	    "id": 1929,
+        "count": [
+          1
+        ],
+        "chance": 2
+      },
+      {
+	    "id": 3711,
+        "count": [
+          1
+        ],
+        "chance": 2
+      },
+      {
+	    "id": 436,
+        "count": [
+          5
+        ],
+        "chance": 2
+      },
+      {
+	    "id": 440,
+        "count": [
+          1
+        ],
+        "chance": 3
+      },
+      {
+        "id": 327,
+        "count": [
+          1
+        ],
+        "chance": 3
+      },
+      {
+	   "id": 1917,
+        "count": [
+          1
+        ],
+        "chance": 6
+      },
+      {
+	   "id": 1891,
+        "count": [
+          1
+        ],
+        "chance": 6
+      },
+      {
+	   "id": 1592,
+        "count": [
+          1
+        ],
+        "chance": 6
+      },
+      {
+	   "id": 1462,
+        "count": [
+          1
+        ],
+        "chance": 6
+      },
+      {
+	   "id": 1337,
+        "count": [
+          1
+        ],
+        "chance": 2
+      },
+      {
+	   "id": 1601,
+        "count": [
+          1
+        ],
+        "chance": 6
+      },
+      {
+	     "id": 1335,
+        "count": [
+          1
+        ],
+        "chance": 2
+      },
+      {
+	     "id": 1339,
+        "count": [
+          1
+        ],
+        "chance": 3
+      },
+      {
+	     "id": 1341,
+        "count": [
+          1
+        ],
+        "chance": 3
+	  },
+      {
+	     "id": 3757,
+        "count": [
+          1
+        ],
+        "chance": 6
+	  },
+      {
+	     "id": 3758,
+        "count": [
+          1
+        ],
+        "chance": 6
+      },
+      {
+	     "id": 3748,
+        "count": [
+          1
+        ],
+        "chance": 6
+      },
+      {
+        "id": 1079,
+        "count": [
+          1
+        ],
+        "chance": 1
+      }
+    ]
+  },
+  {
     "npcId": 1328,
     "rareTableAccess": false,
     "drops": [
@@ -106784,7 +106967,7 @@
         "count": [
           1
         ],
-        "chance": 3
+        "chance": 2
       },
       {
         "id": 3049,
@@ -107030,56 +107213,56 @@
         "count": [
           1
         ],
-        "chance": 2
+        "chance": 6
       },
       {
         "id": 201,
         "count": [
           1
         ],
-        "chance": 2
+        "chance": 6
       },
       {
         "id": 203,
         "count": [
           1
         ],
-        "chance": 2
+        "chance": 6
       },
       {
         "id": 205,
         "count": [
           1
         ],
-        "chance": 3
+        "chance": 6
       },
       {
         "id": 207,
         "count": [
           1
         ],
-        "chance": 3
+        "chance": 6
       },
       {
         "id": 209,
         "count": [
           1
         ],
-        "chance": 3
+        "chance": 6
       },
       {
         "id": 211,
         "count": [
           1
         ],
-        "chance": 3
+        "chance": 6
       },
       {
         "id": 213,
         "count": [
           1
         ],
-        "chance": 3
+        "chance": 6
       },
       {
         "id": 215,
@@ -238848,6 +239031,32 @@
           1
         ],
         "chance": 4
+      }
+    ]
+  },
+  {
+  "npcId": 4479,
+    "rareTableAccess": false,
+    "drops": [
+      {
+        "id": 526,
+        "count": [
+          1
+        ],
+        "chance": 1
+      }
+    ]
+  },
+  {
+  "npcId": 4486,
+    "rareTableAccess": false,
+    "drops": [
+      {
+        "id": 526,
+        "count": [
+          1
+        ],
+        "chance": 1
       }
     ]
   },

--- a/vscape Server/src/com/rs2/model/content/treasuretrails/ClueScroll.java
+++ b/vscape Server/src/com/rs2/model/content/treasuretrails/ClueScroll.java
@@ -64,7 +64,7 @@ public class ClueScroll {
 	public static String[] levelTwoClueNpc = {"Guard", "Tribesman", "Bandit Camp Human", "Cockatrice", "Abyssal Leech", "Pyrefiend", "Harpie Bug Swarm", "Black Guard", "Rellekka Warrior", "Market Guard", "Jogre", "Ice Warrior", "Abyssal Guardian", "Paladin", "Vampire", "Dagannoth", "Skeleton", "Abyssal Walker", "Dagannoth", "Wallasalki", "Mummy", "Giant Rock Crab", "Werewolf", "Hill Giant",
 						    "Alexis", "Boris", "Eduard", "Galina", "Georgy", "Imre", "Irina", "Joseph", "Ksenia", "Liliya", "Lev", "Milla", "Nikita", "Nikolai", "Sofiya", "Svetlana", "Vera", "Yadviga", "Yuri", "Zoja", "Moss Giant"};
 
-	public static String[] levelThreeClueNpc = {"Greater Demon", "Elf Warrior", "Tyras Guard", "Hellhound", "Dragon", "Dagannoth", "Turoth", "Jelly", "Aberrant Specter", "Gargoyle", "Nechryael", "Abyssal Demon", "Black Demon", "Aberrant Spectre", "Bloodveld"};
+	public static String[] levelThreeClueNpc = {"Greater Demon", "Elf Warrior", "Tyras Guard", "Hellhound", "Dragon", "Dagannoth", "Turoth", "Jelly", "Aberrant Specter", "Gargoyle", "Nechryael", "Abyssal Demon", "Black Demon", "Aberrant Spectre"};
 
 	// todo torn page make into mage books + firelighters + reward items to reward
 

--- a/vscape Server/src/com/rs2/model/content/treasuretrails/ClueScroll.java
+++ b/vscape Server/src/com/rs2/model/content/treasuretrails/ClueScroll.java
@@ -61,10 +61,10 @@ public class ClueScroll {
 
 	public static String[] levelOneClueNpc = {"Man", "Woman", "Goblin", "Mugger", "Barbarian", "Farmer", "Al-Kharid", "Thug", "Rock Crabs", "Rogue", "Thief", "H.A.M", "Banshees", "Cave Slime", "Afflicted", "Borrakar", "Freidar", "Freygerd", "Inga", "Jennella", "Lensa", "Lanzig"};
 
-	public static String[] levelTwoClueNpc = {"Guard", "Tribesman", "Bandit Camp Human", "Cockatrice", "Abyssal Leech", "Pyrefiend", "Harpie Bug Swarm", "Black Guard", "Rellekka Warrior", "Market Guard", "Jogre", "Ice Warrior", "Abyssal Guardian", "Paladin", "Vampire", "Dagannoth", "Skeleton", "Abyssal Walker", "Dagannoth", "Wallasalki", "Mummy", "Giant Rock Crab", "Bloodveld", "Werewolf", "Hill Giant",
+	public static String[] levelTwoClueNpc = {"Guard", "Tribesman", "Bandit Camp Human", "Cockatrice", "Abyssal Leech", "Pyrefiend", "Harpie Bug Swarm", "Black Guard", "Rellekka Warrior", "Market Guard", "Jogre", "Ice Warrior", "Abyssal Guardian", "Paladin", "Vampire", "Dagannoth", "Skeleton", "Abyssal Walker", "Dagannoth", "Wallasalki", "Mummy", "Giant Rock Crab", "Werewolf", "Hill Giant",
 						    "Alexis", "Boris", "Eduard", "Galina", "Georgy", "Imre", "Irina", "Joseph", "Ksenia", "Liliya", "Lev", "Milla", "Nikita", "Nikolai", "Sofiya", "Svetlana", "Vera", "Yadviga", "Yuri", "Zoja", "Moss Giant"};
 
-	public static String[] levelThreeClueNpc = {"Greater Demon", "Elf Warrior", "Tyras Guard", "Hellhound", "Dragon", "Dagannoth", "Turoth", "Jelly", "Aberrant Specter", "Gargoyle", "Nechryael", "Abyssal Demon", "Black Demon", "Aberrant Spectre"};
+	public static String[] levelThreeClueNpc = {"Greater Demon", "Elf Warrior", "Tyras Guard", "Hellhound", "Dragon", "Dagannoth", "Turoth", "Jelly", "Aberrant Specter", "Gargoyle", "Nechryael", "Abyssal Demon", "Black Demon", "Aberrant Spectre", "Bloodveld"};
 
 	// todo torn page make into mage books + firelighters + reward items to reward
 


### PR DESCRIPTION
Bloodvelds*

- drops lvl 3 clues instead of 2's
- made all herbs drops rare
- steel scim now common (was uncommon)

Black demons*

- made law runes rare (was common) and changed amount to 3 from 45

Goblins*

- added drop table to all of the goblins in the village, only bones atm
4486, 4479

Relekka Guard

full drop table from 2007 scape wiki

Proper alch value to dds and rune dagger p++