### PR TITLE
Magic-based melee

### DIFF
--- a/vscape Server/data/ruby/npc-combat.rb
+++ b/vscape Server/data/ruby/npc-combat.rb
@@ -27,10 +27,10 @@ class MonkOfZamorak < NpcCombatDef
     end
 end
 
-class BloodVeld < NpcCombatDef
+class Bloodveld < NpcCombatDef
     def attackScripts attacker, victim
         return [
-                BasicAttack.meleeAttack(attacker, victim, AttackStyle::Mode::MAGIC, AttackStyle::Bonus::SLASH, 5, 6, 1552),
+                BasicAttack.meleeAttack(attacker, victim, AttackStyle::Mode::MAGIC, AttackStyle::Bonus::SLASH, 5, 5, 1552),
 	];
     end
 end
@@ -428,6 +428,30 @@ class InfernalMage < NpcCombatDef
 	end
 end
 
+class Pyrefiend < NpcCombatDef
+    def attackScripts attacker, victim
+        return [
+                BasicAttack.meleeAttack(attacker, victim, AttackStyle::Mode::MAGIC, AttackStyle::Bonus::SLASH, 4, 5, 1582),
+	];
+    end
+end
+
+class Jelly < NpcCombatDef
+    def attackScripts attacker, victim
+        return [
+                BasicAttack.meleeAttack(attacker, victim, AttackStyle::Mode::MAGIC, AttackStyle::Bonus::SLASH, 7, 5, 1586),
+	];
+    end
+end
+
+class Banshee < NpcCombatDef
+    def attackScripts attacker, victim
+        return [
+                BasicAttack.meleeAttack(attacker, victim, AttackStyle::Mode::MAGIC, AttackStyle::Bonus::SLASH, 3, 5, 1523),
+	];
+    end
+end
+
 NpcCombatDef.add([2025], Ahrims.new())
 NpcCombatDef.add([2028], Karil.new())
 NpcCombatDef.add([2746], YtHurkot.new()) #.bonusDef(1000, 1000, 1000, 1000, 600)
@@ -465,7 +489,7 @@ NpcCombatDef.add([907], KolodionFirstForm.new())
 NpcCombatDef.add([908], KolodionSecondForm.new())
 NpcCombatDef.add([910], KolodionFourthForm.new())
 NpcCombatDef.add([1046], MonkOfZamorak.new())
-NpcCombatDef.add([1618], BloodVeld.new())
+NpcCombatDef.add([1618], Bloodveld.new())
 NpcCombatDef.add([1351, 1352, 1353, 1354, 1355, 1356], DagannothMother.new())
 NpcCombatDef.add([1341, 1342, 1343], WeakDagannothMelee.new())
 NpcCombatDef.add([1338, 1339, 1340], WeakDagannothRange.new())
@@ -473,3 +497,6 @@ NpcCombatDef.add([3068, 3069, 3070, 3071], SkeletalWyvern.new())
 NpcCombatDef.add([1456, 1457, 1458], MonkeyArcher.new())
 NpcCombatDef.add([1472], JungleDemon.new())
 NpcCombatDef.add([1643], InfernalMage.new())
+NpcCombatDef.add([1633], Pyrefiend.new())
+NpcCombatDef.add([1640], Jelly.new())
+NpcCombatDef.add([1612], Banshee.new())

--- a/vscape Server/src/com/rs2/model/content/combat/CombatManager.java
+++ b/vscape Server/src/com/rs2/model/content/combat/CombatManager.java
@@ -858,7 +858,7 @@ public class CombatManager extends Tick {
         //if (victim.isNpc())
         //    return victim.getBonus(attackStyle.getBonus().toInteger() + AttackStyle.Bonus.values().length);
 		double effectiveDefence = getEffectiveDefence(victim, attackStyle);
-		if(victim.isPlayer() && attackStyle.getAttackType() != AttackType.MAGIC) {
+		if(victim.isPlayer() && attackStyle.getAttackType() != AttackType.MAGIC && attackStyle.getMode() != AttackStyle.Mode.MAGIC) {
 		   effectiveDefence += victim.getBonus(attackStyle.getBonus().toInteger() + AttackStyle.Bonus.values().length); 
 		}
 		int styleBonusDefence = 0;
@@ -868,13 +868,18 @@ public class CombatManager extends Tick {
 				int level = pVictim.getSkill().getLevel()[Skill.MAGIC];
 				effectiveDefence = (int) (Math.floor(level * 0.125) + Math.floor(effectiveDefence * 0.875));
 				styleBonusDefence = 19;
+			} else if (attackStyle.getAttackType() == AttackType.MELEE && attackStyle.getMode() == AttackStyle.Mode.MAGIC){
+				int magicLevel = pVictim.getSkill().getLevel()[Skill.MAGIC];
+				int defenseLevel = pVictim.getSkill().getLevel()[Skill.DEFENCE];
+				effectiveDefence = (int) (Math.floor(magicLevel * 0.0875) + Math.floor(defenseLevel * 0.0375) + Math.floor(effectiveDefence * 0.875));
+				styleBonusDefence = 64;
 			} else {
 				AttackStyle defenceStyle = pVictim.getEquippedWeapon().getWeaponInterface().getAttackStyles()[pVictim.getFightMode()];
-				if (defenceStyle.getMode() == AttackStyle.Mode.DEFENSIVE || defenceStyle.getMode() == AttackStyle.Mode.LONGRANGE)
-					styleBonusDefence += 3;
-				else if (defenceStyle.getMode() == AttackStyle.Mode.CONTROLLED)
-					styleBonusDefence += 1;
-			}
+					if (defenceStyle.getMode() == AttackStyle.Mode.DEFENSIVE || defenceStyle.getMode() == AttackStyle.Mode.LONGRANGE)
+						styleBonusDefence += 3;
+					else if (defenceStyle.getMode() == AttackStyle.Mode.CONTROLLED)
+						styleBonusDefence += 1;
+				}
 		}
 		effectiveDefence *= (1 + (styleBonusDefence) / 64);
 		if (hitDef.getSpecialEffect() == 11) { //verac effect


### PR DESCRIPTION
Magic-based melee attacks given to bloodvelds, pyrefiends, banshees, and
jellies. Corrected the attack speed for bloodvelds as well.